### PR TITLE
Update the finding of scrolling position by id

### DIFF
--- a/sphinx_preview/assets/template_sphinx_preview.js
+++ b/sphinx_preview/assets/template_sphinx_preview.js
@@ -156,8 +156,10 @@ function scrollToContent(iframe) {
   // specify a taget link
   if (target.indexOf("#") != -1) {
       setTimeout(function () {
-          var pos_top_content_iframe = $("#sp_preframe").contents().find('a[href="#' + target.split("#")[1] + '"]').last().offset().top;
-          document.getElementById("sp_preframe").contentDocument.documentElement.scrollTop = pos_top_content_iframe - 25;
-      }, 500);
+        let config = {{ config }};
+        let target_id = target.split("#")[1];
+        let pos_top_content_iframe = $("#sp_preframe").contents().find('#' + target_id).offset().top;
+        document.getElementById("sp_preframe").contentDocument.documentElement.scrollTop = pos_top_content_iframe - config.scroll_offset;
+    }, 500);
   }
 }

--- a/sphinx_preview/sphinx_preview.py
+++ b/sphinx_preview/sphinx_preview.py
@@ -41,7 +41,8 @@ def _save_js_file(app, target):
         "width": config.get('width', 500),
         "height": config.get('height', 300),
         "offset": config.get('offset', {'left': 20, 'top': 20}),
-        "timeout": config.get('timeout', 250)
+        "timeout": config.get('timeout', 250),
+        "scroll_offset": config.get("scroll_offset", 75)
 
     }
     script_dir = os.path.join(os.path.dirname(__file__), 'assets')


### PR DESCRIPTION
# Description
When we integrated the Sphinx Preview extension, we got some problems with the scrolling offset inside the iframe. It didn't scroll to the correct position.

We should find the position inside the iframe by the id instead of the anchor tag. 

## Changes Made

- Modify the `scrollToContent` function to find the `post_top_content_iframe` by id instead of the anchor tag.
- Provide the `scroll_offset` config.

